### PR TITLE
Fix channel number reset to 1 issue

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -48,23 +48,23 @@ _body(NavState state, BuildContext context) {
             },
           ),
         ],
-        child:
-        Scaffold(
+        child: Scaffold(
           body: Container(
             decoration: BoxDecoration(
               image: DecorationImage(
                 image: AssetImage("assets/texture.png"),
-                colorFilter: new ColorFilter.mode(Colors.blueAccent.withOpacity(0.9), BlendMode.dstATop),
-
+                colorFilter: new ColorFilter.mode(
+                    Colors.blueAccent.withOpacity(0.9), BlendMode.dstATop),
                 fit: BoxFit.cover,
               ),
             ),
-            child:   BlocConsumer<EarwigBloc, EarwigState>(listener: (context, state) {
+            child: BlocConsumer<EarwigBloc, EarwigState>(
+                listener: (context, state) {
               if (state is MessageReceivedEarwigState) {
                 Locale myLocale = Localizations.localeOf(context);
                 print('YAY++++' + state.message.message + '++++YAY');
-                BlocProvider.of<HomeBloc>(context)
-                    .add(StartIncomingEvent(state.message, myLocale.languageCode));
+                BlocProvider.of<HomeBloc>(context).add(
+                    StartIncomingEvent(state.message, myLocale.languageCode));
               }
             }, builder: (context, state) {
               var size = MediaQuery.of(context).size;
@@ -115,12 +115,13 @@ _body(NavState state, BuildContext context) {
                                   _channel = channel.toInt();
                                   BlocProvider.of<HomeBloc>(context)
                                       .add(ChannelBrowseEvent(_channel));
-                                  if (BlocProvider.of<EarwigBloc>(context).state !=
+                                  if (BlocProvider.of<EarwigBloc>(context)
+                                          .state !=
                                       EardeafState()) {
                                     BlocProvider.of<EarwigBloc>(context)
                                         .add(StopListeningEvent());
-                                    BlocProvider.of<EarwigBloc>(context)
-                                        .add(StartListeningEvent(currentChannel()));
+                                    BlocProvider.of<EarwigBloc>(context).add(
+                                        StartListeningEvent(currentChannel()));
                                   } else {
                                     //Nothing to do
                                   }
@@ -133,12 +134,11 @@ _body(NavState state, BuildContext context) {
                               )
                             ],
                           ))),
-                  ChannelDisplayWidget(),
+                  ChannelDisplayWidget(currentChannel: _channel),
                 ],
               );
-            })/* add child content here */,
+            }) /* add child content here */,
           ),
-        )
-           );
+        ));
   }
 }

--- a/lib/widgets/channel_display_widget.dart
+++ b/lib/widgets/channel_display_widget.dart
@@ -4,30 +4,23 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutterband/blocs/home/bloc.dart';
 
 class ChannelDisplayWidget extends StatelessWidget {
+  final int currentChannel;
 
-
-  final int currentChannel = 1;
-
-  ChannelDisplayWidget({
-    Key key,
-  }) : super(key: key);
+  ChannelDisplayWidget({@required this.currentChannel});
 
   @override
   Widget build(BuildContext context) {
-
     return BlocBuilder<HomeBloc, HomeState>(builder: (context, state) {
       var channel = state.channel ?? currentChannel;
       return Expanded(
           child: Container(
               alignment: Alignment.center,
-              child: Text(
-                  channel.toString(),
+              child: Text(channel.toString(),
                   style: TextStyle(
                       color: Colors.lightBlueAccent,
                       fontSize: 200,
                       // fontWeight: FontWeight.bold,
                       fontFamily: "Digital"))));
     });
-
   }
 }


### PR DESCRIPTION
The channel number was hardcoded inside the stateless widget, so each time it was redrawn, the value was reset to 1. Just added the channel number as a parameter.